### PR TITLE
Fixed font caching

### DIFF
--- a/Drawing/FontManager.cpp
+++ b/Drawing/FontManager.cpp
@@ -8,6 +8,7 @@
 
 #include "FontManager.hpp"
 #include "../Misc/Exceptions.hpp"
+#include "../Misc/HashTuple.hpp"
 #include "FreeTypeFont.hpp"
 #include <windows.h>
 #include <algorithm>
@@ -18,7 +19,7 @@ namespace OSHGui
 {
 	namespace Drawing
 	{
-		std::unordered_map<Misc::AnsiString, std::weak_ptr<Drawing::Font>> FontManager::loadedFonts;
+		std::unordered_map<std::tuple<Misc::AnsiString, float, bool>, std::weak_ptr<Drawing::Font>> FontManager::loadedFonts;
 		//---------------------------------------------------------------------------
 		FontPtr FontManager::LoadFont(Misc::AnsiString name, float pointSize, bool antiAliased)
 		{
@@ -93,11 +94,12 @@ namespace OSHGui
 		//---------------------------------------------------------------------------
 		FontPtr FontManager::LoadFontFromFile(const Misc::AnsiString &filename, float pointSize, bool antiAliased)
 		{
-			const auto it = loadedFonts.find(filename);
+			auto cacheEntry = std::make_tuple(filename, pointSize, antiAliased);
+			const auto it = loadedFonts.find(cacheEntry);
 			if (it == std::end(loadedFonts) || it->second.expired())
 			{
 				auto font = std::make_shared<FreeTypeFont>(filename, pointSize, antiAliased);
-				loadedFonts[filename] = font;
+				loadedFonts[cacheEntry] = font;
 				return font;
 			}
 			return it->second.lock();

--- a/Drawing/FontManager.hpp
+++ b/Drawing/FontManager.hpp
@@ -52,7 +52,7 @@ namespace OSHGui
 			static void DisplaySizeChanged(const SizeF &size);
 
 		private:
-			static std::unordered_map<Misc::AnsiString, std::weak_ptr<Drawing::Font>> loadedFonts;
+			static std::unordered_map<std::tuple<Misc::AnsiString, float, bool>, std::weak_ptr<Drawing::Font>> loadedFonts;
 		};
 	}
 }

--- a/Misc/HashTuple.hpp
+++ b/Misc/HashTuple.hpp
@@ -1,0 +1,41 @@
+// From https://stackoverflow.com/questions/7110301/generic-hash-for-tuples-in-unordered-map-unordered-set
+// Maybe we should put something like this in a standard header?
+namespace std
+{
+	namespace
+	{
+		template<class T> inline void hash_combine(std::size_t& seed, const T& v)
+		{
+			seed ^= std::hash<T>()(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+		}
+		
+		// Recursive template code derived from Matthieu M.
+		template<class Tuple, size_t Index = std::tuple_size<Tuple>::value - 1>
+		struct HashValueImpl
+		{
+			static void apply(size_t& seed, const Tuple& tuple)
+			{
+				HashValueImpl<Tuple, Index - 1>::apply(seed, tuple);
+				hash_combine(seed, std::get<Index>(tuple));
+			}
+		};
+		
+		template<class Tuple> struct HashValueImpl<Tuple, 0>
+		{
+			static void apply(size_t& seed, const Tuple& tuple)
+			{
+				hash_combine(seed, std::get<0>(tuple));
+			}
+		};
+	}
+	
+	template<class... TT> struct hash<std::tuple<TT...>>
+	{
+		size_t operator()(const std::tuple<TT...>& tt) const
+		{
+			size_t seed = 0;
+			HashValueImpl<std::tuple<TT...> >::apply(seed, tt);
+			return seed;
+		}
+	};
+}


### PR DESCRIPTION
Font caching was done with the fonts name as only key. That led to problems when using the same font more than once with different sizes. After the first usage initializing another font would provide the cached font with the wrong size for the initialization.