### PR TITLE
Handling resolution changes in D3D9

### DIFF
--- a/Drawing/Direct3D9/Direct3D9Renderer.cpp
+++ b/Drawing/Direct3D9/Direct3D9Renderer.cpp
@@ -269,6 +269,7 @@ namespace OSHGui
 		//---------------------------------------------------------------------------
 		void Direct3D9Renderer::PostD3DReset()
 		{
+			SetDisplaySize(GetViewportSize());
 			device->CreateStateBlock(D3DSBT_ALL, &stateBlock);
 
 			RemoveWeakReferences();


### PR DESCRIPTION
When the target changes the resolution to a bigger one, OSHGui was clipped to the old resolution. The fix adapts the resolution of the internal rendering surface after the device has been reset.